### PR TITLE
Add CircleCI / GitlabCI config example + Update action usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2.1
+orbs:
+  saucectl: saucelabs/saucectl-run@1.0.0
+
+jobs:
+  test-playwright:
+    docker:
+      - image: circleci/node:12.21
+    environment:
+      CI_COMMIT_SHORT_SHA: $CIRCLE_SHA1
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 19.03.13
+      - saucectl/saucectl-run:
+          testing-environment: docker
+      - saucectl/saucectl-run:
+          testing-environment: sauce
+
+workflows:
+  version: 2
+  default_workflow:
+    jobs:
+      - test-playwright

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      # Install saucectl
-      - uses: saucelabs/saucectl-run-action@v1
-        with:
-          skip-run: true
-
       - name: Saucectl RUN Docker
-        run: saucectl run --test-env docker --ccy 10
+        uses: saucelabs/saucectl-run-action@v1
+        with:
+          testing-environment: docker
+          concurrency: 10
 
       - name: Saucectl RUN Sauce Cloud
-        run: saucectl run --test-env sauce --ccy 10
+        uses: saucelabs/saucectl-run-action@v1
+        with:
+          testing-environment: sauce
+          concurrency: 10

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,34 @@
+image: alpine:3.9
+
+variables:
+    DOCKER_VERSION: 20.10.5
+    DOCKER_HOST: tcp://docker:2375
+    SAUCECTL_VERSION: 0.34.1
+    SAUCE_USERNAME: ${SAUCE_USERNAME}
+    SAUCE_ACCESS_KEY: ${SAUCE_ACCESS_KEY}
+
+stages:
+  - test
+
+.saucectl:
+  services:
+    - docker:${DOCKER_VERSION}-dind
+  before_script:
+    - apk add curl
+    - curl -L -o saucectl.tar.gz https://github.com/saucelabs/saucectl/releases/download/v${SAUCECTL_VERSION}/saucectl_${SAUCECTL_VERSION}_linux_64-bit.tar.gz
+    - tar -xvzf saucectl.tar.gz
+    - mv saucectl /usr/bin/saucectl
+
+test docker:
+  extends: .saucectl
+  image: docker:${DOCKER_VERSION}
+  stage: test
+  script:
+    - saucectl run -c .sauce/config.yml --test-env docker --ccy 10
+
+test sauce:
+  extends: .saucectl
+  image: docker:${DOCKER_VERSION}
+  stage: test
+  script:
+    - saucectl run -c .sauce/config.yml --test-env sauce --ccy 10


### PR DESCRIPTION
Replaces #1 

Add examples for GitLab-CI / CircleCI and updates `saucelabs/saucectl-run-action@v1` usage.