### PR TITLE
Remove obsolete field from config

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -6,7 +6,6 @@ sauce:
   region: us-west-1
   concurrency: 2 # Controls how many suites are executed at the same time.
   metadata:
-    name: saucectl playwright example
     tags:
       - e2e
       - release team


### PR DESCRIPTION
Has been deprecated a long time ago. Cleaning up config.