### PR TITLE
[DEVX-1442] Comment out docker suites

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -24,21 +24,21 @@ suites:
     testMatch: ['.*.js']
     params:
       browserName: "firefox"
-  - name: "Chromium in docker"
-    mode: docker
-    testMatch: ['.*.js']
-    params:
-      browserName: "chromium"
-  - name: "Firefox in docker"
-    mode: docker
-    testMatch: ['.*.js']
-    params:
-      browserName: "firefox"
-  - name: "Webkit in docker"
-    mode: docker
-    testMatch: ['.*.js']
-    params:
-      browserName: "webkit"
+  # - name: "Chromium in docker"
+  #   mode: docker
+  #   testMatch: ['.*.js']
+  #   params:
+  #     browserName: "chromium"
+  # - name: "Firefox in docker"
+  #   mode: docker
+  #   testMatch: ['.*.js']
+  #   params:
+  #     browserName: "firefox"
+  # - name: "Webkit in docker"
+  #   mode: docker
+  #   testMatch: ['.*.js']
+  #   params:
+  #     browserName: "webkit"
   - name: "Chromium in sauce"
     mode: sauce
     platformName: "Windows 10"


### PR DESCRIPTION
I have gotten feedback from internal folks who have tried to use our Quickstart doc and when they run the test, it fails because they are not using Docker and don't have it set up and the Quickstart doesn't mention it. Since we are defaulting to running on Sauce for the QS, I think it is best to comment out the docker suite in the config.