### PR TITLE
Update defaults

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -4,59 +4,59 @@ defaults:
   mode: sauce
 sauce:
   region: us-west-1
-  concurrency: 2 # Controls how many suites are executed at the same time.
+  concurrency: 10 # Controls how many suites are executed at the same time.
   metadata:
     tags:
       - e2e
       - release team
       - other tag
-    build: Release $CI_COMMIT_SHORT_SHA
+    build: $CI_COMMIT_SHORT_SHA
 docker:
   # Affects how test files are transferred to the docker container when using the docker mode.
   fileTransfer: copy # Choose between mount|copy.
 playwright:
-  version: 1.22.2 # See https://docs.saucelabs.com/dev/cli/saucectl/#supported-frameworks-and-browsers for a list of supported versions.
+  version: 1.24.1 # See https://docs.saucelabs.com/dev/cli/saucectl/#supported-frameworks-and-browsers for a list of supported versions.
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./
 suites:
-  - name: "Firefox using global mode" # Since the suite doesn't specify the `mode`, it'll inherit the mode specified via `defaults.mode` (see line number 3 and 4 of this config file).
-    platformName: "Windows 11" # Only relevant when running a test against the sauce cloud.
+  - name: "Firefox Win"
+    platformName: "Windows 11"
+    screenResolution: "1440x900"
     testMatch: ['.*.js']
     params:
       browserName: "firefox"
-  # - name: "Chromium in docker"
+  - name: "Chromium Mac"
+    platformName: "macOS 12"
+    screenResolution: "1440x900"
+    testMatch: ['.*.js']
+    params:
+      browserName: "chromium"
+  - name: "Webkit Win"
+    platformName: "Windows 11"
+    screenResolution: "1440x900"
+    testMatch: ['.*.js']
+    params:
+      browserName: "webkit"
+  # - name: "Chromium Docker"
   #   mode: docker
   #   testMatch: ['.*.js']
   #   params:
   #     browserName: "chromium"
-  # - name: "Firefox in docker"
+  # - name: "Firefox Docker"
   #   mode: docker
   #   testMatch: ['.*.js']
   #   params:
   #     browserName: "firefox"
-  # - name: "Webkit in docker"
+  # - name: "Webkit Docker"
   #   mode: docker
   #   testMatch: ['.*.js']
   #   params:
   #     browserName: "webkit"
-  - name: "Chromium on Mac"
-    mode: sauce
-    platformName: "macOS 12"
-    testMatch: ['.*.js']
-    params:
-      browserName: "chromium"
-  - name: "Webkit in sauce"
-    mode: sauce
-    platformName: "Windows 11"
-    testMatch: ['.*.js']
-    params:
-      browserName: "webkit"
-
 
 # Controls what artifacts to fetch when the suite on Sauce Cloud has finished.
-artifacts:
-  download:
-    when: always
-    match:
-      - console.log
-    directory: ./artifacts/
+# artifacts:
+#   download:
+#     when: always
+#     match:
+#       - console.log
+#     directory: ./artifacts/


### PR DESCRIPTION
Update a variety of defaults:
- sort the suites so it's not this weird mess of commented/uncommented blocks, but cleaner
- use newest available playwright version
- Use a build name that works perfectly fine locally (build will be empty, hence auto generated by saucectl) and in CI (commit short sha in that case)
- bump concurrency to run all defined suites in parallel
- disable artifact download; absolutely annoying locally and in our CI, since we don't actually utilize the downloaded artifacts
- increase resolution, so that browser view port fits within