### PR TITLE
[DEVX-1868] Add grep by tags examples

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -37,6 +37,20 @@ suites:
     testMatch: ['.*.js']
     params:
       browserName: "webkit"
+  # - name: "Grep tags"
+  #   platformName: "Windows 11"
+  #   screenResolution: "1440x900"
+  #   testMatch: ['.*.js']
+  #   params:
+  #     grep: "@saucelabs"
+  #     browserName: "chromium"
+  # - name: "GrepInvert tags"
+  #   platformName: "Windows 11"
+  #   screenResolution: "1440x900"
+  #   testMatch: ['.*.js']
+  #   params:
+  #     grepInvert: "@saucelabs"
+  #     browserName: "chromium"
   # - name: "Chromium Docker"
   #   mode: docker
   #   testMatch: ['.*.js']

--- a/tests/example.test.js
+++ b/tests/example.test.js
@@ -1,6 +1,25 @@
 const { test, expect } = require('@playwright/test');
 
-test('should verify title of the page', async ({ page }) => {
+test('should verify title of the page @saucelabs', async ({ page }) => {
     await page.goto('https://www.saucedemo.com/');
     expect(await page.title()).toBe('Swag Labs');
+});
+
+test('homepage has Playwright in title and get started link linking to the intro page @playwrightdev', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Playwright/);
+
+  // create a locator
+  const getStarted = page.locator('text=Get Started');
+
+  // Expect an attribute "to be strictly equal" to the value.
+  await expect(getStarted).toHaveAttribute('href', '/docs/intro');
+
+  // Click the get started link.
+  await getStarted.click();
+
+  // Expects the URL to contain intro.
+  await expect(page).toHaveURL(/.*intro/);
 });


### PR DESCRIPTION
Add examples for running filtered tests.
grep: https://app.saucelabs.com/tests/0a50169c97194b948d1fa1b49bb3faf8
grepInvert: https://app.saucelabs.com/tests/a787dac601c448e09c419e3a4d7542d0