### PR TITLE
Fix case-fallthrough

### DIFF
--- a/examples/cucumber/features/support/steps.js
+++ b/examples/cucumber/features/support/steps.js
@@ -11,10 +11,13 @@ Before(async function () {
     switch (process.env.BROWSER_NAME) {
         case 'firefox':
             this.browser = await firefox.launch(opts)
+            break;
         case 'webkit':
             this.browser = await webkit.launch(opts)
+            break;
         default:
             this.browser = await chromium.launch(opts)
+            break;
     }
     const context = await this.browser.newContext();
     this.page = await context.newPage();


### PR DESCRIPTION
Case fallthrough causes multiple browser instances to launch (when using firefox or webkit).

Closes #38.