### PR TITLE
Never open HTML report automatically

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -32,7 +32,7 @@ const config = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [['html', { open: 'never'}]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */


### PR DESCRIPTION
Don't open the HTML report automatically as this can block remote execution environments.