### PR TITLE
Remove references to docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,6 @@ jobs:
       CI_COMMIT_SHORT_SHA: $CIRCLE_SHA1
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 19.03.13
       - saucectl/saucectl-run
 
 workflows:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Saucectl RUN Docker and Cloud
+      - name: Saucectl RUN
         uses: saucelabs/saucectl-run-action@v3
         with:
           concurrency: 10

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,7 @@
 image: alpine:3.9
 
 variables:
-    DOCKER_VERSION: 20.10.5
-    DOCKER_HOST: tcp://docker:2375
-    SAUCECTL_VERSION: 0.82.1
+    SAUCECTL_VERSION: 0.135.0
     SAUCE_USERNAME: ${SAUCE_USERNAME}
     SAUCE_ACCESS_KEY: ${SAUCE_ACCESS_KEY}
 
@@ -11,8 +9,6 @@ stages:
   - test
 
 .saucectl:
-  services:
-    - docker:${DOCKER_VERSION}-dind
   before_script:
     - apk add curl
     - curl -L -o saucectl.tar.gz https://github.com/saucelabs/saucectl/releases/download/v${SAUCECTL_VERSION}/saucectl_${SAUCECTL_VERSION}_linux_64-bit.tar.gz
@@ -21,7 +17,7 @@ stages:
 
 test:
   extends: .saucectl
-  image: docker:${DOCKER_VERSION}
+  image: ubuntu:latest
   stage: test
   script:
     - saucectl run -c .sauce/config.yml --ccy 10

--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -1,7 +1,5 @@
 apiVersion: v1alpha
 kind: playwright
-defaults:
-  mode: sauce
 sauce:
   region: us-west-1
   concurrency: 10 # Controls how many suites are executed at the same time.
@@ -10,9 +8,6 @@ sauce:
       - e2e
       - release team
       - other tag
-docker:
-  # Affects how test files are transferred to the docker container when using the docker mode.
-  fileTransfer: copy # Choose between mount|copy.
 playwright:
   version: package.json # See https://docs.saucelabs.com/web-apps/automated-testing/playwright/#supported-testing-platforms for a list of supported versions.
   configFile: playwright.config.js # See https://docs.saucelabs.com/web-apps/automated-testing/playwright/yaml/#configfile for a list of supported configuration files.
@@ -40,7 +35,7 @@ suites:
     params:
       browserName: "webkit"
       project: "webkit"
-# Controls what artifacts to fetch when the suite on Sauce Cloud has finished.
+# Controls what artifacts to fetch when the suites have finished.
 # artifacts:
 #   download:
 #     when: always

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ saucectl configure
 ## Running The Examples
 Simply check out this repo and run the command below :rocket:
 
-Running saucectl in Sauce cloud
+Running saucectl
 
 ```bash
 saucectl run


### PR DESCRIPTION
Removes all references to docker mode and parts that suggest we can execute somewhere else than on Sauce Labs Cloud.