### PR TITLE
Add example for screenshot info

### DIFF
--- a/tests/example.spec.js
+++ b/tests/example.spec.js
@@ -16,11 +16,8 @@ test('homepage has Playwright in title and get started link linking to the intro
   // Click the get started link.
   await getStarted.click();
   
-  const path = testInfo.outputPath('__assets__/screen_capture.png');
-
-  await page.screenshot({ path });
-
-  testInfo.attachments.push({ name: 'screen_capture.png', path, contentType: 'image/png' });
+  await page.screenshot({ path: 'screen_capture.png' });
+  await testInfo.attach( 'screen_capture.png', { path: 'screen_capture.png', contentType: 'image/png' });
 
   // Expects the URL to contain intro.
   await expect(page).toHaveURL(/.*intro/);

--- a/tests/example.spec.js
+++ b/tests/example.spec.js
@@ -1,7 +1,7 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 
-test('homepage has Playwright in title and get started link linking to the intro page', async ({ page }) => {
+test('homepage has Playwright in title and get started link linking to the intro page', async ({ page }, testInfo) => {
   await page.goto('https://playwright.dev/');
 
   // Expect a title "to contain" a substring.
@@ -16,7 +16,11 @@ test('homepage has Playwright in title and get started link linking to the intro
   // Click the get started link.
   await getStarted.click();
   
-  await page.screenshot({ path: '__assets__/screen_capture.png' });
+  const path = testInfo.outputPath('__assets__/screen_capture.png');
+
+  await page.screenshot({ path });
+
+  testInfo.attachments.push({ name: 'screen_capture.png', path, contentType: 'image/png' });
 
   // Expects the URL to contain intro.
   await expect(page).toHaveURL(/.*intro/);


### PR DESCRIPTION
Checked `sauce-playwright-reporter` and the playwright docs. I think sauce reporter has been already handled the attachments part. It requires test side to push required info. 