### PR TITLE
updating playwright examples for version update

### DIFF
--- a/examples/cucumber/.sauce/config.yml
+++ b/examples/cucumber/.sauce/config.yml
@@ -10,7 +10,7 @@ sauce:
 defaults:
   timeout: 5m
 playwright:
-  version: 1.57.0
+  version: 1.58.1
 rootDir: ./
 suites:
   - name: My Cucumber Test

--- a/examples/cucumber/package-lock.json
+++ b/examples/cucumber/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "dependencies": {
                 "@cucumber/cucumber": "^9.6.0",
-                "@playwright/test": "1.57.0",
+                "@playwright/test": "1.58.1",
                 "@saucelabs/cucumber-reporter": "^1.2.0",
                 "@types/node": "^22.9.4",
                 "ts-node": "^10.9.2",
@@ -120,7 +120,6 @@
             "version": "26.2.0",
             "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-26.2.0.tgz",
             "integrity": "sha512-iRSiK8YAIHAmLrn/mUfpAx7OXZ7LyNlh1zT89RoziSVCbqSVDxJS6ckEzW8loxs+EEXl0dKPQOXiDmbHV+C/fA==",
-            "peer": true,
             "dependencies": {
                 "@cucumber/messages": ">=19.1.4 <=22"
             }
@@ -193,7 +192,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-4.0.1.tgz",
             "integrity": "sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==",
-            "peer": true,
             "peerDependencies": {
                 "@cucumber/messages": ">=17.1.1"
             }
@@ -202,7 +200,6 @@
             "version": "19.1.4",
             "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-19.1.4.tgz",
             "integrity": "sha512-Pksl0pnDz2l1+L5Ug85NlG6LWrrklN9qkMxN5Mv+1XZ3T6u580dnE6mVaxjJRdcOq4tR17Pc0RqIDZMyVY1FlA==",
-            "peer": true,
             "dependencies": {
                 "@types/uuid": "8.3.4",
                 "class-transformer": "0.5.1",
@@ -238,12 +235,12 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.57.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-            "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+            "version": "1.58.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
+            "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.57.0"
+                "playwright": "1.58.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -317,7 +314,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.4.tgz",
             "integrity": "sha512-d9RWfoR7JC/87vj7n+PVTzGg9hDyuFjir3RxUHbjFSKNd9mpxbxwMEyaCim/ddCmy4IuW7HjTzF3g9p3EtWEOg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.19.8"
             }
@@ -947,12 +943,12 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.57.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-            "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+            "version": "1.58.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+            "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.57.0"
+                "playwright-core": "1.58.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -965,9 +961,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.57.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-            "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+            "version": "1.58.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+            "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
@@ -1260,7 +1256,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
             "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/examples/cucumber/package.json
+++ b/examples/cucumber/package.json
@@ -1,7 +1,7 @@
 {
     "dependencies": {
         "@cucumber/cucumber": "^9.6.0",
-        "@playwright/test": "1.57.0",
+        "@playwright/test": "1.58.1",
         "@saucelabs/cucumber-reporter": "^1.2.0",
         "@types/node": "^22.9.4",
         "ts-node": "^10.9.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
             "version": "1.0.0",
             "license": "ISC",
             "devDependencies": {
-                "@playwright/test": "1.57.0",
-                "saucectl": "^0.186.4"
+                "@playwright/test": "1.58.1",
+                "saucectl": "^0.201.0"
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.57.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-            "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+            "version": "1.58.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
+            "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.57.0"
+                "playwright": "1.58.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -441,13 +441,13 @@
             "license": "MIT"
         },
         "node_modules/playwright": {
-            "version": "1.57.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-            "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+            "version": "1.58.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+            "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.57.0"
+                "playwright-core": "1.58.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -460,9 +460,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.57.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-            "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+            "version": "1.58.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+            "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -487,9 +487,9 @@
             "license": "MIT"
         },
         "node_modules/saucectl": {
-            "version": "0.186.4",
-            "resolved": "https://registry.npmjs.org/saucectl/-/saucectl-0.186.4.tgz",
-            "integrity": "sha512-vX1CHDIiKndJx0RGls3GfB7NmW/jriAizv4WLsAzOtqKQpAOPG8PJPaQOO70i26ppihfofLYk/flgnBYixA7Ew==",
+            "version": "0.201.0",
+            "resolved": "https://registry.npmjs.org/saucectl/-/saucectl-0.201.0.tgz",
+            "integrity": "sha512-w6tfHRgZhOD5IZ9rCIi2rEkARtd8Fy+NM65a5pK0zFsa2AjB2N4F+6yVUbWdmVGls5k7bd76BZcS1hu82YfmQQ==",
             "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "homepage": "https://github.com/saucelabs/saucectl-playwright-example#readme",
     "devDependencies": {
-        "@playwright/test": "1.57.0",
-        "saucectl": "^0.186.4"
+        "@playwright/test": "1.58.1",
+        "saucectl": "^0.201.0"
     }
 }


### PR DESCRIPTION
  Summary
                                                                                                                                                                                                                                                                                                                            
  - Bump Playwright framework version from 1.57.0 to 1.58.1
  - Bump saucectl version from ^0.186.4 to ^0.201.0

  Changes

  - Updated @playwright/test to 1.58.1 in package.json and examples/cucumber/package.json
  - Updated saucectl to ^0.201.0 in package.json
  - Updated Playwright version in examples/cucumber/.sauce/config.yml to 1.58.1
  - Regenerated package-lock.json and examples/cucumber/package-lock.json

  Why

  Keep dependencies up to date with the latest supported Playwright and saucectl versions to ensure compatibility with the Sauce Labs platform and access to the latest bug fixes and features.

