### PR TITLE
INT-246: Add macOS 26 ARM example suite

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -36,6 +36,14 @@ suites:
     params:
       browserName: "webkit"
       project: "webkit"
+  - name: "Webkit Mac ARM"
+    platformName: "macOS 26"
+    screenResolution: "1440x900"
+    testMatch: [".*.js"]
+    armRequired: true
+    params:
+      browserName: "webkit"
+      project: "webkit"
 # Controls what artifacts to fetch when the suites have finished.
 # artifacts:
 #   download:


### PR DESCRIPTION
Adds a macOS 26 ARM example suite, mirroring the existing macOS suites. macOS 26 is now live and validated on prod for Playwright (verified end-to-end via devx-e2e). Part of INT-246 (macOS 26 enablement).