### PR TITLE
INT-542: Bump examples to playwright 1.61.1 (July default)

### DIFF
--- a/examples/cucumber/.sauce/config.yml
+++ b/examples/cucumber/.sauce/config.yml
@@ -10,7 +10,7 @@ sauce:
 defaults:
   timeout: 5m
 playwright:
-  version: 1.58.1
+  version: 1.61.1
 rootDir: ./
 suites:
   - name: My Cucumber Test

--- a/examples/cucumber/package-lock.json
+++ b/examples/cucumber/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "dependencies": {
                 "@cucumber/cucumber": "^9.6.0",
-                "@playwright/test": "1.58.1",
+                "@playwright/test": "1.61.1",
                 "@saucelabs/cucumber-reporter": "^1.2.0",
                 "@types/node": "^22.9.4",
                 "ts-node": "^10.9.2",
@@ -120,6 +120,7 @@
             "version": "26.2.0",
             "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-26.2.0.tgz",
             "integrity": "sha512-iRSiK8YAIHAmLrn/mUfpAx7OXZ7LyNlh1zT89RoziSVCbqSVDxJS6ckEzW8loxs+EEXl0dKPQOXiDmbHV+C/fA==",
+            "peer": true,
             "dependencies": {
                 "@cucumber/messages": ">=19.1.4 <=22"
             }
@@ -192,6 +193,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-4.0.1.tgz",
             "integrity": "sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==",
+            "peer": true,
             "peerDependencies": {
                 "@cucumber/messages": ">=17.1.1"
             }
@@ -200,6 +202,7 @@
             "version": "19.1.4",
             "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-19.1.4.tgz",
             "integrity": "sha512-Pksl0pnDz2l1+L5Ug85NlG6LWrrklN9qkMxN5Mv+1XZ3T6u580dnE6mVaxjJRdcOq4tR17Pc0RqIDZMyVY1FlA==",
+            "peer": true,
             "dependencies": {
                 "@types/uuid": "8.3.4",
                 "class-transformer": "0.5.1",
@@ -235,12 +238,12 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.58.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
-            "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+            "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.58.1"
+                "playwright": "1.61.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -314,6 +317,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.4.tgz",
             "integrity": "sha512-d9RWfoR7JC/87vj7n+PVTzGg9hDyuFjir3RxUHbjFSKNd9mpxbxwMEyaCim/ddCmy4IuW7HjTzF3g9p3EtWEOg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.19.8"
             }
@@ -943,12 +947,12 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.58.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
-            "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+            "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.58.1"
+                "playwright-core": "1.61.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -961,9 +965,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.58.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
-            "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+            "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
@@ -1256,6 +1260,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
             "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/examples/cucumber/package.json
+++ b/examples/cucumber/package.json
@@ -1,7 +1,7 @@
 {
     "dependencies": {
         "@cucumber/cucumber": "^9.6.0",
-        "@playwright/test": "1.58.1",
+        "@playwright/test": "1.61.1",
         "@saucelabs/cucumber-reporter": "^1.2.0",
         "@types/node": "^22.9.4",
         "ts-node": "^10.9.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
             "version": "1.0.0",
             "license": "ISC",
             "devDependencies": {
-                "@playwright/test": "1.58.1",
+                "@playwright/test": "1.61.1",
                 "saucectl": "^0.201.0"
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.58.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
-            "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+            "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.58.1"
+                "playwright": "1.61.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -441,13 +441,13 @@
             "license": "MIT"
         },
         "node_modules/playwright": {
-            "version": "1.58.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
-            "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+            "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.58.1"
+                "playwright-core": "1.61.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -460,9 +460,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.58.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
-            "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+            "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "homepage": "https://github.com/saucelabs/saucectl-playwright-example#readme",
     "devDependencies": {
-        "@playwright/test": "1.58.1",
+        "@playwright/test": "1.61.1",
         "saucectl": "^0.201.0"
     }
 }


### PR DESCRIPTION
**Draft — merge when playwright 1.61.1 is live** (test-composer deployed). Part of the July runner update (INT-542).

Bumps the cucumber example's playwright `version` 1.58.1 → 1.61.1. The main `.sauce/config.yml` uses `version: package.json` (version-agnostic — uses the installed @playwright/test), so no change needed there.